### PR TITLE
pull stakingTokens inside stakingContract 

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       deploy: ["deploy/core", "deploy/main"],
       accounts: {
-        mnemonic: process.env.MNEMONIC
+        mnemonic: process.env.MNEMONIC,
       },
       forking: {
         url: process.env.MAINNET_URL || "",
@@ -44,7 +44,7 @@ const config: HardhatUserConfig = {
       url: process.env.GOERLI_URL || "",
       deploy: ["deploy/core", "deploy/test"],
       accounts: {
-        mnemonic: process.env.MNEMONIC
+        mnemonic: process.env.MNEMONIC,
       },
     },
     mainnet: {
@@ -52,7 +52,6 @@ const config: HardhatUserConfig = {
       deploy: ["deploy/core", "deploy/main"],
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-     
     },
   },
   paths: {

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -232,8 +232,8 @@ contract Staking is Ownable {
             info.expiry != 0 &&
             info.amount != 0 &&
             ((requestedWithdrawals.minCycle <= currentCycleIndex &&
-                requestedWithdrawals.amount + stakingTokenBalance >= info.amount) ||
-                stakingTokenBalance >= info.amount);
+                requestedWithdrawals.amount + stakingTokenBalance >=
+                info.amount) || stakingTokenBalance >= info.amount);
     }
 
     /**
@@ -623,7 +623,7 @@ contract Staking is Ownable {
             _amount
         );
 
-        // deposit all staking tokens held in contract to Tokemak
+        // deposit all staking tokens held in contract to Tokemak minus tokens waiting for claimWithdrawal
         uint256 stakingTokenBalance = IERC20(STAKING_TOKEN).balanceOf(
             address(this)
         );

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -228,8 +228,9 @@ contract Staking is Ownable {
             epoch.number >= info.expiry &&
             info.expiry != 0 &&
             info.amount != 0 &&
-            requestedWithdrawals.minCycle <= currentCycleIndex &&
-            requestedWithdrawals.amount + withdrawalAmount >= info.amount;
+            ((requestedWithdrawals.minCycle <= currentCycleIndex &&
+                requestedWithdrawals.amount + withdrawalAmount >=
+                info.amount) || withdrawalAmount >= info.amount);
     }
 
     /**

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -251,6 +251,7 @@ contract Staking is Ownable {
         ) {
             tokePoolContract.withdraw(requestedWithdrawals.amount);
             requestWithdrawalAmount -= requestedWithdrawals.amount;
+            withdrawalAmount += requestedWithdrawals.amount;
         }
     }
 
@@ -427,6 +428,7 @@ contract Staking is Ownable {
                 address(this),
                 totalAmountIncludingRewards
             );
+            withdrawalAmount -= info.amount;
         }
     }
 
@@ -622,7 +624,7 @@ contract Staking is Ownable {
             _amount
         );
 
-        // deposit all staking tokens held in contract to Tokemak minus tokens waiting for claimWithdrawal
+        // deposit all staking tokens held in contract to Tokemak minus tokens waiting for claimWithdraw
         uint256 stakingTokenBalance = IERC20(STAKING_TOKEN).balanceOf(
             address(this)
         );

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -46,7 +46,8 @@ contract Staking is Ownable {
     uint256 public blocksLeftToRequestWithdrawal; // amount of blocks before TOKE cycle ends to request withdrawal
     uint256 public warmUpPeriod; // amount of epochs to delay warmup vesting
     uint256 public coolDownPeriod; // amount of epochs to delay cooldown vesting
-    uint256 public requestWithdrawalAmount; // amount of tokens to request withdrawal once able to send
+    uint256 public requestWithdrawalAmount; // amount of staking tokens to request withdrawal once able to send
+    uint256 public withdrawalAmount; // amount of stakings tokens available for withdrawal
     uint256 public lastTokeCycleIndex; // last tokemak cycle index which requested withdrawals
 
     constructor(
@@ -198,7 +199,11 @@ contract Staking is Ownable {
         @param _recipient address - warmup address to check if claim is available
         @return bool - true if available to claim
      */
-    function _isClaimAvailable(address _recipient) internal view returns (bool) {
+    function _isClaimAvailable(address _recipient)
+        internal
+        view
+        returns (bool)
+    {
         Claim memory info = warmUpInfo[_recipient];
         return epoch.number >= info.expiry && info.expiry != 0;
     }
@@ -219,23 +224,35 @@ contract Staking is Ownable {
         RequestedWithdrawalInfo memory requestedWithdrawals = tokePoolContract
             .requestedWithdrawals(address(this));
         uint256 currentCycleIndex = tokeManager.getCurrentCycleIndex();
-
+        uint256 stakingTokenBalance = IERC20(STAKING_TOKEN).balanceOf(
+            address(this)
+        );
         return
             epoch.number >= info.expiry &&
             info.expiry != 0 &&
             info.amount != 0 &&
-            requestedWithdrawals.minCycle <= currentCycleIndex &&
-            requestedWithdrawals.amount >= info.amount;
+            ((requestedWithdrawals.minCycle <= currentCycleIndex &&
+                requestedWithdrawals.amount + stakingTokenBalance >= info.amount) ||
+                stakingTokenBalance >= info.amount);
     }
 
     /**
         @notice withdraw stakingTokens from Tokemak
         @dev needs a valid requestWithdrawal inside Tokemak with a completed cycle rollover to withdraw
-        @param _amount uint - amount of stakingTokens to withdraw
      */
-    function _withdrawFromTokemak(uint256 _amount) internal {
+    function _withdrawFromTokemak() internal {
         ITokePool tokePoolContract = ITokePool(TOKE_POOL);
-        tokePoolContract.withdraw(_amount);
+        ITokeManager tokeManager = ITokeManager(TOKE_MANAGER);
+        RequestedWithdrawalInfo memory requestedWithdrawals = tokePoolContract
+            .requestedWithdrawals(address(this));
+        uint256 currentCycleIndex = tokeManager.getCurrentCycleIndex();
+        if (
+            requestedWithdrawals.amount > 0 &&
+            requestedWithdrawals.minCycle <= currentCycleIndex
+        ) {
+            tokePoolContract.withdraw(requestedWithdrawals.amount);
+            requestWithdrawalAmount -= requestedWithdrawals.amount;
+        }
     }
 
     /**
@@ -278,10 +295,10 @@ contract Staking is Ownable {
         uint256 currentCycleStart = tokeManager.getCurrentCycle();
         uint256 currentCycleIndex = tokeManager.getCurrentCycleIndex();
         uint256 nextCycleStart = currentCycleStart + duration;
-
         return
             block.number + blocksLeftToRequestWithdrawal >= nextCycleStart &&
-            currentCycleIndex > lastTokeCycleIndex;
+            currentCycleIndex > lastTokeCycleIndex &&
+            requestWithdrawalAmount > 0;
     }
 
     /**
@@ -295,7 +312,7 @@ contract Staking is Ownable {
         );
         // pause any future staking
         shouldPauseStaking(true);
-
+        requestWithdrawalAmount = tokePoolBalance;
         _requestWithdrawalFromTokemak(tokePoolBalance);
     }
 
@@ -305,8 +322,14 @@ contract Staking is Ownable {
     function sendWithdrawalRequests() public {
         // check to see if near the end of a TOKE cycle
         if (_canBatchTransactions()) {
+            // if has withdrawal amount to be claimed then claim
+            _withdrawFromTokemak();
+
+            // if more requestWithdrawalAmount exists after _withdrawFromTokemak then request the new amount
             ITokeManager tokeManager = ITokeManager(TOKE_MANAGER);
-            _requestWithdrawalFromTokemak(requestWithdrawalAmount);
+            if (requestWithdrawalAmount > 0) {
+                _requestWithdrawalFromTokemak(requestWithdrawalAmount);
+            }
 
             uint256 currentCycleIndex = tokeManager.getCurrentCycleIndex();
             lastTokeCycleIndex = currentCycleIndex;
@@ -391,11 +414,9 @@ contract Staking is Ownable {
         Claim memory info = coolDownInfo[_recipient];
         uint256 totalAmountIncludingRewards = IRewardToken(REWARD_TOKEN)
             .balanceForGons(info.gons);
-
         if (_isClaimWithdrawAvailable(_recipient)) {
-            _withdrawFromTokemak(info.amount);
-            // subtract withdrawn from amount to request from tokemak
-            requestWithdrawalAmount -= info.amount;
+            // if has withdrawalAmount to be claimed, then claim
+            _withdrawFromTokemak();
 
             delete coolDownInfo[_recipient];
 
@@ -606,7 +627,8 @@ contract Staking is Ownable {
         uint256 stakingTokenBalance = IERC20(STAKING_TOKEN).balanceOf(
             address(this)
         );
-        _depositToTokemak(stakingTokenBalance);
+        uint256 amountToDeposit = stakingTokenBalance - withdrawalAmount;
+        _depositToTokemak(amountToDeposit);
 
         if (_trigger) {
             rebase();

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -224,15 +224,12 @@ contract Staking is Ownable {
         RequestedWithdrawalInfo memory requestedWithdrawals = tokePoolContract
             .requestedWithdrawals(address(this));
         uint256 currentCycleIndex = tokeManager.getCurrentCycleIndex();
-        uint256 stakingTokenBalance = IERC20(STAKING_TOKEN).balanceOf(
-            address(this)
-        );
         return
             epoch.number >= info.expiry &&
             info.expiry != 0 &&
             info.amount != 0 &&
             requestedWithdrawals.minCycle <= currentCycleIndex &&
-            requestedWithdrawals.amount + stakingTokenBalance >= info.amount;
+            requestedWithdrawals.amount + withdrawalAmount >= info.amount;
     }
 
     /**

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -231,9 +231,8 @@ contract Staking is Ownable {
             epoch.number >= info.expiry &&
             info.expiry != 0 &&
             info.amount != 0 &&
-            ((requestedWithdrawals.minCycle <= currentCycleIndex &&
-                requestedWithdrawals.amount + stakingTokenBalance >=
-                info.amount) || stakingTokenBalance >= info.amount);
+            requestedWithdrawals.minCycle <= currentCycleIndex &&
+            requestedWithdrawals.amount + stakingTokenBalance >= info.amount;
     }
 
     /**

--- a/test/contracts/integration.ts
+++ b/test/contracts/integration.ts
@@ -71,7 +71,7 @@ describe("Integration", function () {
       rewardTokenDeployment.abi,
       accounts[0]
     ) as Foxy;
-    
+
     const stakingDeployment = await deployments.get("Staking");
     staking = new ethers.Contract(
       stakingDeployment.address,
@@ -322,7 +322,7 @@ describe("Integration", function () {
 
     // unstake with staker3
     await stakingStaker3.unstake(warmUpStaker3Reward, true);
-    
+
     // add another set of rewards with belong to no one due to all FOXy being locked in cooldown
     await staking.addRewardsForStakers(awardAmount, true);
     cooldownRewardTokenBalance = await rewardToken.balanceOf(

--- a/test/contracts/stakingTest.ts
+++ b/test/contracts/stakingTest.ts
@@ -1658,7 +1658,7 @@ describe("Staking", function () {
 
       await stakingStaker1.sendWithdrawalRequests();
 
-      let stakingTokenBalance = await stakingToken.balanceOf(staking.address)
+      let stakingTokenBalance = await stakingToken.balanceOf(staking.address);
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
@@ -1671,11 +1671,13 @@ describe("Staking", function () {
 
       await stakingStaker2.claimWithdraw(staker2);
 
-      stakingTokenBalance = await stakingToken.balanceOf(staking.address)
+      stakingTokenBalance = await stakingToken.balanceOf(staking.address);
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(stakingAmount1);
+      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(
+        stakingAmount1
+      );
 
       await rewardToken
         .connect(staker3Signer as Signer)
@@ -1687,7 +1689,7 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // finally, it goes through
-      stakingTokenBalance = await stakingToken.balanceOf(staking.address)
+      stakingTokenBalance = await stakingToken.balanceOf(staking.address);
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
@@ -1775,7 +1777,9 @@ describe("Staking", function () {
       // sendWithdrawalRequests work now
       await stakingStaker1.sendWithdrawalRequests();
 
-      let stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
+      let stakingContractTokenBalance = await stakingToken.balanceOf(
+        staking.address
+      );
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
@@ -1792,7 +1796,9 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // requestedWithdrawals not updated due to cycle index not being updated
-      stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
+      stakingContractTokenBalance = await stakingToken.balanceOf(
+        staking.address
+      );
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
@@ -1805,7 +1811,9 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // finally, it goes through
-      stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
+      stakingContractTokenBalance = await stakingToken.balanceOf(
+        staking.address
+      );
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
@@ -1875,13 +1883,17 @@ describe("Staking", function () {
       expect(lastCycle.toNumber()).lessThan(nextCycle.toNumber());
 
       // next requestedWithdrawals should be
-      let stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
+      const stakingContractTokenBalance = await stakingToken.balanceOf(
+        staking.address
+      );
       const requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
 
       const totalStakingAmount = stakingAmount2.add(stakingAmount1);
-      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(totalStakingAmount);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
+        totalStakingAmount
+      );
 
       // both should be able to claim
       await tokeManagerOwner.completeRollover(LATEST_CLAIMABLE_HASH);
@@ -2163,7 +2175,7 @@ describe("Staking", function () {
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
-      const stakingTokenBalance = await stakingToken.balanceOf(staking.address)
+      const stakingTokenBalance = await stakingToken.balanceOf(staking.address);
 
       expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(
         stakingAmount2.add(stakingAmount1)
@@ -2370,11 +2382,15 @@ describe("Staking", function () {
       await mineBlocksToNextCycle();
       await stakingStaker1.sendWithdrawalRequests();
 
-      const stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
+      const stakingContractTokenBalance = await stakingToken.balanceOf(
+        staking.address
+      );
       let requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
-      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(stakingAmount1);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
+        stakingAmount1
+      );
 
       await staking.unstakeAllFromTokemak();
 
@@ -2382,7 +2398,9 @@ describe("Staking", function () {
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
-      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(totalStaking);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
+        totalStaking
+      );
 
       // can't stake
       await expect(

--- a/test/contracts/stakingTest.ts
+++ b/test/contracts/stakingTest.ts
@@ -1658,10 +1658,11 @@ describe("Staking", function () {
 
       await stakingStaker1.sendWithdrawalRequests();
 
+      let stakingTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(
         stakingAmount1.add(stakingAmount2)
       );
 
@@ -1670,10 +1671,11 @@ describe("Staking", function () {
 
       await stakingStaker2.claimWithdraw(staker2);
 
+      stakingTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(stakingAmount1);
+      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(stakingAmount1);
 
       await rewardToken
         .connect(staker3Signer as Signer)
@@ -1685,10 +1687,11 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // finally, it goes through
+      stakingTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(
         stakingAmount1.add(stakingAmount3)
       );
     });
@@ -1772,10 +1775,11 @@ describe("Staking", function () {
       // sendWithdrawalRequests work now
       await stakingStaker1.sendWithdrawalRequests();
 
+      let stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
         stakingAmount1.add(stakingAmount2)
       );
 
@@ -1788,10 +1792,11 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // requestedWithdrawals not updated due to cycle index not being updated
+      stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
         stakingAmount1.add(stakingAmount2)
       );
 
@@ -1800,10 +1805,11 @@ describe("Staking", function () {
       await stakingStaker3.sendWithdrawalRequests();
 
       // finally, it goes through
+      stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         staking.address
       );
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(
         stakingAmount1.add(stakingAmount2).add(stakingAmount3)
       );
     });
@@ -1869,12 +1875,13 @@ describe("Staking", function () {
       expect(lastCycle.toNumber()).lessThan(nextCycle.toNumber());
 
       // next requestedWithdrawals should be
+      let stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
       const requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
 
       const totalStakingAmount = stakingAmount2.add(stakingAmount1);
-      expect(requestedWithdrawals.amount).eq(totalStakingAmount);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(totalStakingAmount);
 
       // both should be able to claim
       await tokeManagerOwner.completeRollover(LATEST_CLAIMABLE_HASH);
@@ -2156,8 +2163,9 @@ describe("Staking", function () {
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
+      const stakingTokenBalance = await stakingToken.balanceOf(staking.address)
 
-      expect(requestedWithdrawals.amount).eq(
+      expect(requestedWithdrawals.amount.add(stakingTokenBalance)).eq(
         stakingAmount2.add(stakingAmount1)
       );
     });
@@ -2362,10 +2370,11 @@ describe("Staking", function () {
       await mineBlocksToNextCycle();
       await stakingStaker1.sendWithdrawalRequests();
 
+      const stakingContractTokenBalance = await stakingToken.balanceOf(staking.address)
       let requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
-      expect(requestedWithdrawals.amount).eq(stakingAmount1);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(stakingAmount1);
 
       await staking.unstakeAllFromTokemak();
 
@@ -2373,7 +2382,7 @@ describe("Staking", function () {
       requestedWithdrawals = await tokePool.requestedWithdrawals(
         stakingStaker1.address
       );
-      expect(requestedWithdrawals.amount).eq(totalStaking);
+      expect(requestedWithdrawals.amount.add(stakingContractTokenBalance)).eq(totalStaking);
 
       // can't stake
       await expect(


### PR DESCRIPTION
Previously the contract was withdrawing from Tokemak directly on the `claimWithdraw` function.

This had unintended side effects due to Tokemak resetting the minCycle everytime someone calls the `sendWithdrawalRequests` function.
If a user had available funds to claim, but someone called `sendWithdrawalRequests` then the user would have to wait another cycle to call `claimWithdraw`.

This PR changes the logic so that when someone calls `sendWithdrawalRequests` or `claimWithdraw` we withdraw the claimable amount from Tokemak and hold it inside the contract so if they want to withdraw it's not dependent on Tokemak cycles.  

This did not break any tests other than checking for the requestedWithdrawalAmount, which if combined with the stakingTokenBalance we have the exact same amount.