### PR TITLE
Change epoch length from blocks to time

### DIFF
--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -28,6 +28,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
         address _affilateAddress,
         uint256 _epochDuration,
         uint256 _firstEpochNumber,
+        uint256 _firstEpochEndTime,
         uint256 _timeLeftToRequestWithdrawal
     ) external initializer {
         OwnableUpgradeable.__Ownable_init();
@@ -72,7 +73,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
             duration: _epochDuration,
             number: _firstEpochNumber,
             timestamp: block.timestamp,
-            endTime: block.timestamp + _epochDuration,
+            endTime: _firstEpochEndTime,
             distribute: 0
         });
     }
@@ -626,7 +627,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function rebase() public {
         if (epoch.endTime <= block.timestamp) {
-            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.timestamp);
+            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.number);
 
             epoch.endTime = epoch.endTime + epoch.duration;
             epoch.timestamp = block.timestamp;

--- a/src/contracts/test/StakingUpgradeTest.sol
+++ b/src/contracts/test/StakingUpgradeTest.sol
@@ -27,6 +27,7 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
         address _liquidityReserve,
         uint256 _epochDuration,
         uint256 _firstEpochNumber,
+        uint256 _firstEpochEndTime,
         uint256 _timeLeftToRequestWithdrawal
     ) external initializer {
         OwnableUpgradeable.__Ownable_init();
@@ -70,7 +71,7 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
             duration: _epochDuration,
             number: _firstEpochNumber,
             timestamp: block.timestamp,
-            endTime: block.timestamp + _epochDuration,
+            endTime: _firstEpochEndTime,
             distribute: 0 // TODO: don't reset epoch rewards
         });
     }
@@ -581,7 +582,7 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
      */
     function rebase() public {
         if (epoch.endTime <= block.timestamp) {
-            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.timestamp);
+            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.number);
 
             epoch.endTime = epoch.endTime + epoch.duration;
             epoch.timestamp = block.timestamp;

--- a/src/contracts/test/StakingUpgradeTest.sol
+++ b/src/contracts/test/StakingUpgradeTest.sol
@@ -25,9 +25,8 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
         address _tokeManager,
         address _tokeReward,
         address _liquidityReserve,
-        uint256 _epochLength,
+        uint256 _epochDuration,
         uint256 _firstEpochNumber,
-        uint256 _firstEpochBlock,
         uint256 _timeLeftToRequestWithdrawal
     ) external initializer {
         OwnableUpgradeable.__Ownable_init();
@@ -68,9 +67,10 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
         );
 
         epoch = Epoch({
-            length: _epochLength,
+            duration: _epochDuration,
             number: _firstEpochNumber,
-            endBlock: _firstEpochBlock,
+            timestamp: block.timestamp,
+            endTime: block.timestamp + _epochDuration,
             distribute: 0 // TODO: don't reset epoch rewards
         });
     }
@@ -134,12 +134,12 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
     }
 
     /**
-        @notice set epoch length
+        @notice set epoch duration
         @dev epoch's determine how long until a rebase can occur
-        @param length uint
+        @param duration uint
      */
-    function setEpochLength(uint256 length) external onlyOwner {
-        epoch.length = length;
+    function setEpochDuration(uint256 duration) external onlyOwner {
+        epoch.duration = duration;
     }
 
     /**
@@ -580,10 +580,11 @@ contract StakingV2Test is OwnableUpgradeable, StakingStorage {
         @notice trigger rebase if epoch has ended
      */
     function rebase() public {
-        if (epoch.endBlock <= block.number) {
-            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.number);
+        if (epoch.endTime <= block.timestamp) {
+            IRewardToken(REWARD_TOKEN).rebase(epoch.distribute, epoch.timestamp);
 
-            epoch.endBlock = epoch.endBlock + epoch.length;
+            epoch.endTime = epoch.endTime + epoch.duration;
+            epoch.timestamp = block.timestamp;
             epoch.number++;
 
             uint256 balance = contractBalance();

--- a/src/structs/Epoch.sol
+++ b/src/structs/Epoch.sol
@@ -2,8 +2,9 @@
 pragma solidity 0.8.9;
 
 struct Epoch {
-    uint256 length; // length of epoch
+    uint256 duration; // length of the epoch (in seconds)
     uint256 number; // epoch number (starting 1)
-    uint256 endBlock; // block that current epoch ends on
+    uint256 timestamp; // epoch start time
+    uint256 endTime; // time that current epoch ends on
     uint256 distribute; // amount of rewards to distribute this epoch
 }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -12,5 +12,5 @@ export const TOKE_MANAGER = "0xa86e412109f77c45a3bc1c5870b880492fb86a14";
 export const TOKE_REWARD = "0x79dD22579112d8a5F7347c5ED7E609e60da713C5"; // TOKE reward contract address
 export const LATEST_CLAIMABLE_HASH =
   "QmWCH3fhEfceBYQhC1hkeM7RZ8FtDeZxSF4hDnpkogXM6W";
-export const EPOCH_LENGTH = 44800;
+export const EPOCH_DURATION = 604800; // 1 week
 export const FIRST_EPOCH_NUMBER = 1;

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -93,6 +93,10 @@ describe("Integration", function () {
       yieldy.address,
     ])) as LiquidityReserve;
 
+    const currentBlock = await ethers.provider.getBlockNumber();
+    const currentTime = (await ethers.provider.getBlock(currentBlock))
+      .timestamp;
+    const firstEpochEndTime = currentTime + constants.EPOCH_DURATION;
     const timeLeftToRequestWithdrawal = 43200;
 
     const stakingDeployment = await ethers.getContractFactory("Staking");
@@ -107,6 +111,7 @@ describe("Integration", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       constants.FIRST_EPOCH_NUMBER,
+      firstEpochEndTime,
       timeLeftToRequestWithdrawal,
     ])) as Staking;
 

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -41,6 +41,13 @@ describe("Integration", function () {
     }
   }
 
+  // skips EVM time equal to epoch duration
+  async function mineToNextEpoch() {
+    const epochLength = (await staking.epoch()).duration.toNumber();
+    await network.provider.send("evm_increaseTime", [epochLength + 10]);
+    await network.provider.send("hardhat_mine");
+  }
+
   beforeEach(async () => {
     const { admin } = await getNamedAccounts();
 
@@ -86,8 +93,6 @@ describe("Integration", function () {
       yieldy.address,
     ])) as LiquidityReserve;
 
-    const currentBlock = await ethers.provider.getBlockNumber();
-    const firstEpochBlock = currentBlock + constants.EPOCH_LENGTH;
     const timeLeftToRequestWithdrawal = 43200;
 
     const stakingDeployment = await ethers.getContractFactory("Staking");
@@ -100,9 +105,8 @@ describe("Integration", function () {
       constants.TOKE_REWARD,
       liquidityReserve.address,
       ethers.constants.AddressZero,
-      constants.EPOCH_LENGTH,
+      constants.EPOCH_DURATION,
       constants.FIRST_EPOCH_NUMBER,
-      firstEpochBlock,
       timeLeftToRequestWithdrawal,
     ])) as Staking;
 
@@ -284,25 +288,10 @@ describe("Integration", function () {
     await staking.addRewardsForStakers(awardAmount, true);
 
     // rebase
-    let currentBlock = await ethers.provider.getBlockNumber();
-    let nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
-
+    await mineToNextEpoch();
     await staking.rebase();
 
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
+    await mineToNextEpoch();
     await staking.rebase();
 
     // instantUnstake with staker1
@@ -349,25 +338,10 @@ describe("Integration", function () {
     expect(cooldownRewardTokenBalance).eq(182222222222221);
 
     // rebase
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
-
+    await mineToNextEpoch();
     await staking.rebase();
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
 
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
-
+    await mineToNextEpoch();
     await staking.rebase();
 
     // complete rollover & send withdraw requests to read withdraw for
@@ -406,23 +380,10 @@ describe("Integration", function () {
     expect(lpStakingBalance).eq(897613444916262);
 
     // rebase
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
+    await mineToNextEpoch();
     await staking.rebase();
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
 
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
+    await mineToNextEpoch();
     await staking.rebase();
 
     // stake with lp2
@@ -472,24 +433,10 @@ describe("Integration", function () {
     await staking.addRewardsForStakers(awardAmount, false);
 
     // rebase
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
+    await mineToNextEpoch();
     await staking.rebase();
 
-    currentBlock = await ethers.provider.getBlockNumber();
-    nextRewardBlock = (await staking.epoch()).endBlock.toNumber();
-
-    // mining 256 blocks at a time
-    for (let i = currentBlock / 256; i <= nextRewardBlock / 256; i++) {
-      await network.provider.send("hardhat_mine", ["0x100"]);
-      currentBlock = await ethers.provider.getBlockNumber();
-    }
+    await mineToNextEpoch();
     await staking.rebase();
 
     // complete rollover to increase tokeIndex

--- a/test/liquidityReserveTest.ts
+++ b/test/liquidityReserveTest.ts
@@ -61,6 +61,10 @@ describe("Liquidity Reserve", function () {
     ])) as Yieldy;
     await rewardToken.deployed();
 
+    const currentBlock = await ethers.provider.getBlockNumber();
+    const currentTime = (await ethers.provider.getBlock(currentBlock))
+      .timestamp;
+    const firstEpochEndTime = currentTime + constants.EPOCH_DURATION;
     const timeLeftToRequestWithdrawal = 43200;
 
     stakingToken = new ethers.Contract(
@@ -91,6 +95,7 @@ describe("Liquidity Reserve", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       constants.FIRST_EPOCH_NUMBER,
+      firstEpochEndTime,
       timeLeftToRequestWithdrawal,
     ])) as Staking;
 

--- a/test/liquidityReserveTest.ts
+++ b/test/liquidityReserveTest.ts
@@ -61,8 +61,6 @@ describe("Liquidity Reserve", function () {
     ])) as Yieldy;
     await rewardToken.deployed();
 
-    const currentBlock = await ethers.provider.getBlockNumber();
-    const firstEpochBlock = currentBlock + constants.EPOCH_LENGTH;
     const timeLeftToRequestWithdrawal = 43200;
 
     stakingToken = new ethers.Contract(
@@ -91,9 +89,8 @@ describe("Liquidity Reserve", function () {
       constants.TOKE_REWARD,
       liquidityReserve.address,
       ethers.constants.AddressZero,
-      constants.EPOCH_LENGTH,
+      constants.EPOCH_DURATION,
       constants.FIRST_EPOCH_NUMBER,
-      firstEpochBlock,
       timeLeftToRequestWithdrawal,
     ])) as Staking;
 

--- a/test/stakingTest.ts
+++ b/test/stakingTest.ts
@@ -105,6 +105,10 @@ describe("Staking", function () {
       rewardToken.address,
     ])) as LiquidityReserve;
 
+    const currentBlock = await ethers.provider.getBlockNumber();
+    const currentTime = (await ethers.provider.getBlock(currentBlock))
+      .timestamp;
+    const firstEpochEndTime = currentTime + constants.EPOCH_DURATION;
     const timeLeftToRequestWithdrawal = 43200;
 
     const stakingDeployment = await ethers.getContractFactory("Staking");
@@ -119,6 +123,7 @@ describe("Staking", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       constants.FIRST_EPOCH_NUMBER,
+      firstEpochEndTime,
       timeLeftToRequestWithdrawal,
     ])) as Staking;
 
@@ -402,6 +407,11 @@ describe("Staking", function () {
     });
     it("Fails when no staking/reward token or staking contract is passed in", async () => {
       const stakingFactory = await ethers.getContractFactory("Staking");
+
+      const currentBlock = await ethers.provider.getBlockNumber();
+      const currentTime = (await ethers.provider.getBlock(currentBlock))
+        .timestamp;
+      const firstEpochEndTime = currentTime + constants.EPOCH_DURATION;
       const timeLeftToRequestWithdrawal = 43200;
 
       // fail due to bad addresses
@@ -417,6 +427,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;
@@ -432,6 +443,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;
@@ -447,6 +459,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;
@@ -462,6 +475,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;
@@ -477,6 +491,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;
@@ -492,6 +507,7 @@ describe("Staking", function () {
           ethers.constants.AddressZero,
           constants.EPOCH_DURATION,
           constants.FIRST_EPOCH_NUMBER,
+          firstEpochEndTime,
           timeLeftToRequestWithdrawal,
         ])
       ).to.be.reverted;


### PR DESCRIPTION
- [x] Refactor all code to use block.timestamp
- [x] Update all tests to ensure they are passing and add any additional tests required to confirm your functionality is working as intended

There are a couple of changes with the tests. I implemented a new `mineToNextEpoch()` function that makes them more readable. It also makes use of `evm_increaseTime` instead of mining lots of blocks, so the tests have been sped up by about 30%, which is quite significant since they used to take 6+ mins.

    
    
