### PR TITLE
Round instant unstake fee up instead of down

### DIFF
--- a/src/contracts/LiquidityReserve.sol
+++ b/src/contracts/LiquidityReserve.sol
@@ -193,7 +193,8 @@ contract LiquidityReserve is
         // claim the stakingToken from previous unstakes
         IStaking(stakingContract).claimWithdraw(address(this));
 
-        uint256 amountMinusFee = _amount - ((_amount * fee) / BASIS_POINTS);
+        uint256 amountMinusFee = (_amount * (BASIS_POINTS - fee)) /
+            BASIS_POINTS;
 
         IERC20Upgradeable(rewardToken).safeTransferFrom(
             msg.sender,

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -303,7 +303,7 @@ describe("Integration", function () {
     const rewardBalanceStaker1 = await yieldy.balanceOf(staker1);
     expect(rewardBalanceStaker1).eq(0);
     const stakingBalanceStaker1 = await stakingToken.balanceOf(staker1);
-    expect(stakingBalanceStaker1).eq(74158730158730);
+    expect(stakingBalanceStaker1).eq(74158730158729);
 
     // stake with staker3
     await stakingStaker3.functions["stake(uint256)"](stakingAmount3);
@@ -451,6 +451,6 @@ describe("Integration", function () {
     warmUpLP2Reward = await yieldy.tokenBalanceForCredits(warmUpInfo.credits);
     expect(warmUpLP2Reward).eq(0);
     const stakingBalanceLP2 = await stakingToken.balanceOf(liquidityProvider2);
-    expect(stakingBalanceLP2).eq(753646311488562); // 80% of 942057889360702
+    expect(stakingBalanceLP2).eq(753646311488561); // 80% of 942057889360702
   });
 });

--- a/test/migrationTest.ts
+++ b/test/migrationTest.ts
@@ -573,9 +573,10 @@ describe("Migration", function () {
       await stakingV2Staker1.instantUnstakeReserve(transferAmount);
 
       const unstakingFee = await liquidityReserveV2.fee();
-      const balanceMinusFee = transferAmount.sub(
-        transferAmount.mul(unstakingFee).div(BigNumber.from("10000"))
-      );
+      const basisFee = BigNumber.from("10000").sub(unstakingFee);
+      const balanceMinusFee = transferAmount
+        .mul(basisFee)
+        .div(BigNumber.from("10000"));
 
       // should be unstaked with the correct fee
       await confirmBalance(staker1, stakingToken, balanceMinusFee);


### PR DESCRIPTION
Reference issue:
https://github.com/code-423n4/2022-06-yieldy-findings/issues/9