### PR TITLE
adds totalSupplyLimit to enable guarded launch 

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -13,6 +13,7 @@ async function main() {
   const currentBlockNumber = await ethers.provider.getBlockNumber();
   const currentBlock = await ethers.provider.getBlock(currentBlockNumber);
   const firstEpochEndTime = currentBlock.timestamp + epochLength;
+  const totalSupplyLimit = ethers.constants.MaxUint256;
 
   const Staking = await ethers.getContractFactory("Staking");
   const yieldyDeployment = await ethers.getContractFactory("Yieldy");
@@ -50,6 +51,7 @@ async function main() {
     curvePool,
     epochLength,
     firstEpochEndTime,
+    totalSupplyLimit,
   ]);
   await staking.deployed();
   console.info("Staking deployed to:", staking.address);

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -237,7 +237,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      * @param _vestingPeriod uint
      */
     function setWarmUpPeriod(uint256 _vestingPeriod) external onlyOwner {
-        require(_vestingPeriod < MAX_VESTING_PERIOD, "Vesting Period too large");
+        require(_vestingPeriod <= MAX_VESTING_PERIOD, "Vesting Period too large");
         warmUpPeriod = _vestingPeriod;
         emit LogSetWarmUpPeriod(_vestingPeriod);
     }
@@ -247,7 +247,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      * @param _vestingPeriod uint
      */
     function setCoolDownPeriod(uint256 _vestingPeriod) external onlyOwner {
-        require(_vestingPeriod < MAX_VESTING_PERIOD, "Vesting Period too large");
+        require(_vestingPeriod <= MAX_VESTING_PERIOD, "Vesting Period too large");
         coolDownPeriod = _vestingPeriod;
         emit LogSetCoolDownPeriod(_vestingPeriod);
     }

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -237,7 +237,10 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      * @param _vestingPeriod uint
      */
     function setWarmUpPeriod(uint256 _vestingPeriod) external onlyOwner {
-        require(_vestingPeriod <= MAX_VESTING_PERIOD, "Vesting Period too large");
+        require(
+            _vestingPeriod <= MAX_VESTING_PERIOD,
+            "Vesting Period too large"
+        );
         warmUpPeriod = _vestingPeriod;
         emit LogSetWarmUpPeriod(_vestingPeriod);
     }
@@ -247,7 +250,10 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      * @param _vestingPeriod uint
      */
     function setCoolDownPeriod(uint256 _vestingPeriod) external onlyOwner {
-        require(_vestingPeriod <= MAX_VESTING_PERIOD, "Vesting Period too large");
+        require(
+            _vestingPeriod <= MAX_VESTING_PERIOD,
+            "Vesting Period too large"
+        );
         coolDownPeriod = _vestingPeriod;
         emit LogSetCoolDownPeriod(_vestingPeriod);
     }
@@ -434,7 +440,10 @@ contract Staking is OwnableUpgradeable, StakingStorage {
         require(_amount > 0, "Must have valid amount");
 
         uint256 yieldyTotalSupply = IYieldy(YIELDY_TOKEN).totalSupply();
-        require(yieldyTotalSupply + _amount <= totalSupplyLimit, "Over total supply limit");
+        require(
+            yieldyTotalSupply + _amount <= totalSupplyLimit,
+            "Over total supply limit"
+        );
 
         // Don't rebase unless tokens are already staked or could get locked out of staking
         if (yieldyTotalSupply > 0) {

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -43,7 +43,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
         address _curvePool,
         uint256 _epochDuration,
         uint256 _firstEpochEndTime,
-        uint256 _totalSupplyLimit,
+        uint256 _totalSupplyLimit
     ) external initializer {
         OwnableUpgradeable.__Ownable_init();
 
@@ -178,7 +178,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
         @param _totalSupplyLimit uint can be set to uint256.max to disable limits. 
     */
     function setTotalSupplyLimit(uint256 _totalSupplyLimit) external onlyOwner {
-        totalSupplyLimit = __totalSupplyLimit;
+        totalSupplyLimit = _totalSupplyLimit;
         emit LogSetTotalSupplyLimit(_totalSupplyLimit);
     }
 
@@ -434,7 +434,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
         require(_amount > 0, "Must have valid amount");
 
         uint256 yieldyTotalSupply = IYieldy(YIELDY_TOKEN).totalSupply();
-        require(yieldyTotalSupply + amount <= totalSupplyLimit, "Over total supply limit");
+        require(yieldyTotalSupply + _amount <= totalSupplyLimit, "Over total supply limit");
 
         // Don't rebase unless tokens are already staked or could get locked out of staking
         if (yieldyTotalSupply > 0) {

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -20,21 +20,14 @@ contract Staking is OwnableUpgradeable, StakingStorage {
     using SafeERC20Upgradeable for IERC20Upgradeable;
     address private constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
-    event LogSetEpochDuration(uint256 indexed blockNumber, uint256 duration);
-    event LogSetWarmUpPeriod(uint256 indexed blockNumber, uint256 period);
-    event LogSetCoolDownPeriod(uint256 indexed blockNumber, uint256 period);
-    event LogSetPauseStaking(uint256 indexed blockNumber, bool shouldPause);
-    event LogSetPauseUnstaking(uint256 indexed blockNumber, bool shouldPause);
-    event LogSetPauseInstantUnstaking(
-        uint256 indexed blockNumber,
-        bool shouldPause
-    );
-    event LogSetAffiliateAddress(
-        uint256 indexed blockNumber,
-        address affilateAddress
-    );
-    event LogSetAffiliateFee(uint256 indexed blockNumber, uint256 fee);
-
+    event LogSetEpochDuration(uint256 duration);
+    event LogSetWarmUpPeriod(uint256 period);
+    event LogSetCoolDownPeriod(uint256 period);
+    event LogSetPauseStaking(bool shouldPause);
+    event LogSetPauseUnstaking(bool shouldPause);
+    event LogSetPauseInstantUnstaking(bool shouldPause);
+    event LogSetAffiliateAddress(address affiliateAddress);
+    event LogSetAffiliateFee(uint256 fee);
     event LogSetCurvePool(address indexed curvePool, int128 to, int128 from);
     event LogSetTotalSupplyLimit(uint256 totalSupplyLimit);
 
@@ -175,7 +168,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function setAffiliateFee(uint256 _affiliateFee) external onlyOwner {
         affiliateFee = _affiliateFee;
-        emit LogSetAffiliateFee(block.number, _affiliateFee);
+        emit LogSetAffiliateFee(_affiliateFee);
     }
 
     /**
@@ -196,7 +189,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function setAffiliateAddress(address _affiliateAddress) external onlyOwner {
         FEE_ADDRESS = _affiliateAddress;
-        emit LogSetAffiliateAddress(block.number, _affiliateAddress);
+        emit LogSetAffiliateAddress(_affiliateAddress);
     }
 
     /**
@@ -206,7 +199,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function shouldPauseStaking(bool _shouldPause) public onlyOwner {
         isStakingPaused = _shouldPause;
-        emit LogSetPauseStaking(block.number, _shouldPause);
+        emit LogSetPauseStaking(_shouldPause);
     }
 
     /**
@@ -216,7 +209,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function shouldPauseUnstaking(bool _shouldPause) external onlyOwner {
         isUnstakingPaused = _shouldPause;
-        emit LogSetPauseUnstaking(block.number, _shouldPause);
+        emit LogSetPauseUnstaking(_shouldPause);
     }
 
     /**
@@ -226,7 +219,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function shouldPauseInstantUnstaking(bool _shouldPause) external onlyOwner {
         isInstantUnstakingPaused = _shouldPause;
-        emit LogSetPauseInstantUnstaking(block.number, _shouldPause);
+        emit LogSetPauseInstantUnstaking(_shouldPause);
     }
 
     /**
@@ -236,7 +229,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      */
     function setEpochDuration(uint256 duration) external onlyOwner {
         epoch.duration = duration;
-        emit LogSetEpochDuration(block.number, duration);
+        emit LogSetEpochDuration(duration);
     }
 
     /**
@@ -246,7 +239,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
     function setWarmUpPeriod(uint256 _vestingPeriod) external onlyOwner {
         require(_vestingPeriod < MAX_VESTING_PERIOD, "Vesting Period too large");
         warmUpPeriod = _vestingPeriod;
-        emit LogSetWarmUpPeriod(block.number, _vestingPeriod);
+        emit LogSetWarmUpPeriod(_vestingPeriod);
     }
 
     /**
@@ -256,7 +249,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
     function setCoolDownPeriod(uint256 _vestingPeriod) external onlyOwner {
         require(_vestingPeriod < MAX_VESTING_PERIOD, "Vesting Period too large");
         coolDownPeriod = _vestingPeriod;
-        emit LogSetCoolDownPeriod(block.number, _vestingPeriod);
+        emit LogSetCoolDownPeriod(_vestingPeriod);
     }
 
     /**

--- a/src/contracts/Staking.sol
+++ b/src/contracts/Staking.sol
@@ -225,11 +225,11 @@ contract Staking is OwnableUpgradeable, StakingStorage {
     /**
         @notice set epoch duration
         @dev epoch's determine how long until a rebase can occur
-        @param duration uint
+        @param _duration uint
      */
-    function setEpochDuration(uint256 duration) external onlyOwner {
-        epoch.duration = duration;
-        emit LogSetEpochDuration(duration);
+    function setEpochDuration(uint256 _duration) external onlyOwner {
+        epoch.duration = _duration;
+        emit LogSetEpochDuration(_duration);
     }
 
     /**
@@ -821,7 +821,7 @@ contract Staking is OwnableUpgradeable, StakingStorage {
      * @notice trades rewards generated from claimFromTokemak for staking token
      * @dev this is function is called from claimFromTokemak if the autoRebase bool is set to true
      */
-    function preSign(bytes calldata orderUid) external onlyOwner {
-        ICowSettlement(COW_SETTLEMENT).setPreSignature(orderUid, true);
+    function preSign(bytes calldata _orderUid) external onlyOwner {
+        ICowSettlement(COW_SETTLEMENT).setPreSignature(_orderUid, true);
     }
 }

--- a/src/contracts/StakingStorage.sol
+++ b/src/contracts/StakingStorage.sol
@@ -34,11 +34,11 @@ contract StakingStorage {
     uint256 public requestWithdrawalAmount; // amount of staking tokens to request withdrawal once able to send
     uint256 public withdrawalAmount; // amount of stakings tokens available for withdrawal
     uint256 public lastTokeCycleIndex; // last tokemak cycle index which requested withdrawals
-    uint256 public affiliateFee;    // fee to send TOKE rewards
-    uint256 public totalSupplyLimit;  // allows for guarded launch, limiting totalSupply from staking
+    uint256 public affiliateFee; // fee to send TOKE rewards
+    uint256 public totalSupplyLimit; // allows for guarded launch, limiting totalSupply from staking
 
     uint256 public constant BASIS_POINTS = 10000; // 100% in basis points
-    uint256 public constant MAX_VESTING_PERIOD = 11; // 11 weeks max lock down to prevent 
+    uint256 public constant MAX_VESTING_PERIOD = 11; // 11 weeks max lock down to prevent
 
     int128 public curvePoolFrom;
     int128 public curvePoolTo;

--- a/src/contracts/StakingStorage.sol
+++ b/src/contracts/StakingStorage.sol
@@ -34,10 +34,11 @@ contract StakingStorage {
     uint256 public requestWithdrawalAmount; // amount of staking tokens to request withdrawal once able to send
     uint256 public withdrawalAmount; // amount of stakings tokens available for withdrawal
     uint256 public lastTokeCycleIndex; // last tokemak cycle index which requested withdrawals
-    uint256 public affiliateFee; // fee to send TOKE rewards
+    uint256 public affiliateFee;    // fee to send TOKE rewards
+    uint256 public totalSupplyLimit;  // allows for guarded launch, limiting totalSupply from staking
 
     uint256 public constant BASIS_POINTS = 10000; // 100% in basis points
-    uint256 public constant MAX_VESTING_PERIOD = 11; // 11 weeks max lockdown to prevent 
+    uint256 public constant MAX_VESTING_PERIOD = 11; // 11 weeks max lock down to prevent 
 
     int128 public curvePoolFrom;
     int128 public curvePoolTo;

--- a/test/batchRequests.ts
+++ b/test/batchRequests.ts
@@ -102,6 +102,7 @@ describe("BatchRequests", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     staking2 = (await upgrades.deployProxy(stakingDeployment, [
@@ -116,6 +117,7 @@ describe("BatchRequests", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     staking3 = (await upgrades.deployProxy(stakingDeployment, [
@@ -130,6 +132,7 @@ describe("BatchRequests", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     const batchDeployment = await ethers.getContractFactory("BatchRequests");

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -106,6 +106,7 @@ describe("Integration", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     const tokeManagerAddress = await tokePool.manager();

--- a/test/liquidityReserveTest.ts
+++ b/test/liquidityReserveTest.ts
@@ -93,6 +93,7 @@ describe("Liquidity Reserve", function () {
       ethers.constants.AddressZero,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     await network.provider.request({

--- a/test/migrationTest.ts
+++ b/test/migrationTest.ts
@@ -170,6 +170,7 @@ describe("Migration", function () {
       constants.CURVE_POOL,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as StakingV2Test;
 
     await network.provider.request({

--- a/test/stakingTest.ts
+++ b/test/stakingTest.ts
@@ -2661,11 +2661,11 @@ describe("Staking", function () {
       await stakingAdmin.shouldPauseStaking(true);
       await stakingAdmin.shouldPauseUnstaking(true);
 
-      await expect(stakingAdmin.setCoolDownPeriod(11)).to.be.revertedWith(
+      await expect(stakingAdmin.setCoolDownPeriod(12)).to.be.revertedWith(
         "Vesting Period too large"
       );
 
-      await expect(stakingAdmin.setWarmUpPeriod(11)).to.be.revertedWith(
+      await expect(stakingAdmin.setWarmUpPeriod(12)).to.be.revertedWith(
         "Vesting Period too large"
       );
 
@@ -2673,7 +2673,7 @@ describe("Staking", function () {
 
       await stakingAdmin.setTimeLeftToRequestWithdrawal(10);
       const timeLeftToRequest = await staking.timeLeftToRequestWithdrawal();
-      await expect(timeLeftToRequest).eq(10);
+      expect(timeLeftToRequest).eq(10);
 
       // transfer STAKING_TOKEN to staker 1
       const transferAmount = BigNumber.from("10000");
@@ -2773,6 +2773,7 @@ describe("Staking", function () {
       );
       expect(requestedWithdrawals.amount).eq(tokeBalance);
     });
+
     it("Emergency exit is working", async () => {
       const { staker1, staker2, staker3 } = await getNamedAccounts();
 

--- a/test/stakingTest.ts
+++ b/test/stakingTest.ts
@@ -2942,7 +2942,9 @@ describe("Staking", function () {
       const transferAmount = BigNumber.from("20000");
       await stakingToken.transfer(staker1, transferAmount);
       const stakingAmount = transferAmount.div(2);
-      const stakingTokenWStakerSigner = stakingToken.connect(staker1Signer as Signer);
+      const stakingTokenWStakerSigner = stakingToken.connect(
+        staker1Signer as Signer
+      );
       await stakingTokenWStakerSigner.approve(staking.address, transferAmount);
 
       await stakingWAdminSigner.setTotalSupplyLimit(stakingAmount.sub(1));

--- a/test/stakingTest.ts
+++ b/test/stakingTest.ts
@@ -121,6 +121,7 @@ describe("Staking", function () {
       constants.CURVE_POOL,
       constants.EPOCH_DURATION,
       firstEpochEndTime,
+      ethers.constants.MaxUint256, // unlimited staking enabled.
     ])) as Staking;
 
     const tokeManagerAddress = await tokePool.manager();
@@ -424,6 +425,7 @@ describe("Staking", function () {
         ethers.constants.AddressZero,
         constants.EPOCH_DURATION,
         firstEpochEndTime,
+        ethers.constants.MaxUint256, // unlimited staking enabled.
       ])) as Staking;
 
       await network.provider.request({

--- a/test/stakingTest.ts
+++ b/test/stakingTest.ts
@@ -2899,4 +2899,67 @@ describe("Staking", function () {
       expect(stakingTokenBalance).eq(stakingAmount3);
     });
   });
+
+  describe("totalSupplyLimit", () => {
+    it("is correctly set on initial deploy", async () => {
+      const initialValue = await staking.totalSupplyLimit();
+      expect(initialValue).to.be.equal(ethers.constants.MaxUint256);
+    });
+
+    it("can only be set by the owner", async () => {
+      const { admin, staker1 } = await getNamedAccounts();
+      const adminSigner = accounts.find((account) => account.address === admin);
+      const staker1Signer = accounts.find(
+        (account) => account.address === staker1
+      );
+      const stakingWAdminSigner = staking.connect(adminSigner as Signer);
+      const stakingWRandoSigner = staking.connect(staker1Signer as Signer);
+      await expect(
+        stakingWRandoSigner.setTotalSupplyLimit(5000)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+      await stakingWAdminSigner.setTotalSupplyLimit(5000); // should not revert
+    });
+
+    it("emits an event when set", async () => {
+      const { admin } = await getNamedAccounts();
+      const adminSigner = accounts.find((account) => account.address === admin);
+      const stakingWAdminSigner = staking.connect(adminSigner as Signer);
+      await expect(stakingWAdminSigner.setTotalSupplyLimit(5000))
+        .to.emit(staking, "LogSetTotalSupplyLimit")
+        .withArgs(5000);
+    });
+
+    it("limits staking correctly when set with no total supply", async () => {
+      const { admin, staker1 } = await getNamedAccounts();
+      const adminSigner = accounts.find((account) => account.address === admin);
+      const staker1Signer = accounts.find(
+        (account) => account.address === staker1
+      );
+      const stakingWAdminSigner = staking.connect(adminSigner as Signer);
+      const stakingWStakerSigner = staking.connect(staker1Signer as Signer);
+
+      // transfer STAKING_TOKEN to staker 1
+      const transferAmount = BigNumber.from("20000");
+      await stakingToken.transfer(staker1, transferAmount);
+      const stakingAmount = transferAmount.div(2);
+      const stakingTokenWStakerSigner = stakingToken.connect(staker1Signer as Signer);
+      await stakingTokenWStakerSigner.approve(staking.address, transferAmount);
+
+      await stakingWAdminSigner.setTotalSupplyLimit(stakingAmount.sub(1));
+      // fails due to staking being paused
+      await expect(
+        stakingWStakerSigner.functions["stake(uint256)"](stakingAmount)
+      ).to.be.revertedWith("Over total supply limit");
+
+      await stakingWAdminSigner.setTotalSupplyLimit(stakingAmount);
+      await stakingWStakerSigner.functions["stake(uint256)"](stakingAmount);
+      // should fail now that we will be over the limit
+      await expect(
+        stakingWStakerSigner.functions["stake(uint256)"](stakingAmount)
+      ).to.be.revertedWith("Over total supply limit");
+
+      await stakingWAdminSigner.setTotalSupplyLimit(transferAmount); // increase limit
+      await stakingWStakerSigner.functions["stake(uint256)"](stakingAmount);
+    });
+  });
 });


### PR DESCRIPTION
This PR mainly aims to add functionality to be able to control the total supply of a specific yieldy increasing through more staking than desired at the launch of the product. An owner can set totalSupplyLimit which will disable new stakers from entering when the total supply of yieldies is beyond the set `totalSupplyLimit`.  Full tests are included for the new functionality 

Additionally it provides a few cleanup items

- removes block numbers from events (@toshiSat - let me know if this was specific reason those were there, they shouldn't be necessary as you can always query a block by its number)
- cleans up some small style things with function input vars not having the same format (_inputVar)
- Fixes the off by one error in the MAX_VESTING_PERIOD to be inclusive. 